### PR TITLE
1.24.x compatibility

### DIFF
--- a/SpecialDuoAuth.php
+++ b/SpecialDuoAuth.php
@@ -11,7 +11,7 @@ class SpecialDuoAuth extends SpecialPage {
   }
 
   function execute( $par ) {
-    global $wgUser, $mediaWiki, $wgRequest, $wgOut, $wgDuoIKey, $wgDuoSKey, $wgDuoHost, $IP, $wgServer, $wgScriptPath, $wgSecretKey;
+    global $wgUser, $mediaWiki, $wgRequest, $wgOut, $wgDuoIKey, $wgDuoSKey, $wgDuoHost, $IP, $wgServer, $wgScriptPath, $wgScript, $wgSecretKey;
 
     $this->setHeaders();
     require_once("$IP/extensions/DuoAuth/duo_web.php");
@@ -41,7 +41,7 @@ class SpecialDuoAuth extends SpecialPage {
         $wgUser->setId($_SESSION['id']);
         $wgUser->loadFromId();
         $wgUser->setCookies();
-        $wgOut->redirect("Main_Page");
+        $wgOut->redirect("$wgScript/Main Page");
       } else {
         $mediaWiki->restInPeace();
       }

--- a/SpecialDuoAuth.php
+++ b/SpecialDuoAuth.php
@@ -4,7 +4,6 @@ class SpecialDuoAuth extends SpecialPage {
 
   function __construct() {
     parent::__construct( 'DuoAuth' );
-    wfLoadExtensionMessages('DuoAuth');
   }
 
   function getName() {


### PR DESCRIPTION
A Call to undefined function wfLoadExtensionMessages() on Line 7. wfLoadExtensionMessages was removed per MediaWiki r52503. Error begins showing in MW 1.21.1 This commit fixes fatal error. 

When using default install without Short URL's the redirect after duo success breaks because the redirect assumes wiki configuration using Short URL. $wgScript/Main Page resolves this breakage.

All tests were done on MediaWiki 1.24.1